### PR TITLE
Add log statements whenever reasonable

### DIFF
--- a/backend/src/main/java/de/wevsvirushackathon/coronareport/DummyDataInputBean.java
+++ b/backend/src/main/java/de/wevsvirushackathon/coronareport/DummyDataInputBean.java
@@ -14,6 +14,8 @@ import de.wevsvirushackathon.coronareport.symptomes.SymptomRepository;
 import de.wevsvirushackathon.coronareport.client.Client;
 import de.wevsvirushackathon.coronareport.client.ClientRepository;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.Ordered;
@@ -27,6 +29,8 @@ import java.util.*;
 @Component
 //@Profile("!prod")
 public class DummyDataInputBean implements ApplicationListener<ContextRefreshedEvent>, Ordered {
+
+    private final Logger log = LoggerFactory.getLogger(DummyDataInputBean.class);
 
     private ClientRepository clientRepository;
     private ContactPersonRepository contactPersonRepository;
@@ -53,8 +57,11 @@ public class DummyDataInputBean implements ApplicationListener<ContextRefreshedE
     	
     	Client client = clientRepository.findByClientCode("738d3d1f-a9f1-4619-9896-2b5cb3a89c22");
     	if(client != null){
+            log.info("Initial client data already exists, skipping dummy data generation");
     		return;
     	}
+
+        log.info("Generating dummy data");
 
         final HealthDepartment hd1 = this.healthDepartmentRepository.save(HealthDepartment.builder().fullName("Testamt 1")
                 .id("Testamt1").passCode(UUID.fromString("aba0ec65-6c1d-4b7b-91b4-c31ef16ad0a2")).build());

--- a/backend/src/main/java/de/wevsvirushackathon/coronareport/SimpleCORSFilter.java
+++ b/backend/src/main/java/de/wevsvirushackathon/coronareport/SimpleCORSFilter.java
@@ -17,41 +17,41 @@ import org.springframework.stereotype.Component;
 
 /**
  * Allows requests from different domains as the one on which the api runs.
- *
+ * <p>
  * TODO This effectively disables Cors. It is a means for development during MVP, will be replaced before production.
- * @author Patrick Otto
  *
+ * @author Patrick Otto
  */
 @Component
 public class SimpleCORSFilter implements Filter {
 
-private final Logger log = LoggerFactory.getLogger(SimpleCORSFilter.class);
+    private final Logger log = LoggerFactory.getLogger(SimpleCORSFilter.class);
 
-public SimpleCORSFilter() {
-    log.info("SimpleCORSFilter init");
-}
+    public SimpleCORSFilter() {
+        log.info("SimpleCORSFilter init");
+    }
 
-@Override
-public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
 
-    HttpServletRequest request = (HttpServletRequest) req;
-    HttpServletResponse response = (HttpServletResponse) res;
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
 
-    response.setHeader("Access-Control-Allow-Origin", request.getHeader("Origin"));
-    response.setHeader("Access-Control-Allow-Credentials", "true");
-    response.setHeader("Access-Control-Allow-Methods", "POST, PUT, HEAD, GET, OPTIONS, DELETE");
-    response.setHeader("Access-Control-Max-Age", "3600");
-    response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Headers, client-code, Origin,Accept, X-Requested-With, remember-me, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers");
+        response.setHeader("Access-Control-Allow-Origin", request.getHeader("Origin"));
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+        response.setHeader("Access-Control-Allow-Methods", "POST, PUT, HEAD, GET, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Headers, client-code, Origin,Accept, X-Requested-With, remember-me, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers");
 
-    chain.doFilter(req, res);
-}
+        chain.doFilter(req, res);
+    }
 
-@Override
-public void init(FilterConfig filterConfig) {
-}
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
 
-@Override
-public void destroy() {
-}
+    @Override
+    public void destroy() {
+    }
 
 }

--- a/backend/src/main/java/de/wevsvirushackathon/coronareport/diary/DiaryEntryController.java
+++ b/backend/src/main/java/de/wevsvirushackathon/coronareport/diary/DiaryEntryController.java
@@ -11,7 +11,10 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.HttpServletResponse;
 
+import de.wevsvirushackathon.coronareport.report.HDReportService;
 import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -47,6 +50,8 @@ import io.swagger.annotations.ApiResponses;
  */
 @RestController
 public class DiaryEntryController {
+
+	private final Logger log = LoggerFactory.getLogger(DiaryEntryController.class);
 
 	private DiaryEntryRepository diaryEntryRepository;
 	private ClientRepository userRepository;
@@ -256,6 +261,8 @@ public class DiaryEntryController {
 				"clientId;firstname;surename;dateTime;bodyTemperature;symptoms;contactFirstname;contactSurename;typeOfContract;typeOfProtection");
 
 		final String valueSep = ";";
+
+		log.info(String.format("Exporting demoralized CSV of %d diary entries", diaryEntryCollection.size()));
 
 		for (final DiaryEntry d : diaryEntryCollection) {
 			final Collection<ContactPerson> contactPersonCollection = d.getContactPersons().size() == 0

--- a/backend/src/main/java/de/wevsvirushackathon/coronareport/report/HDReportService.java
+++ b/backend/src/main/java/de/wevsvirushackathon/coronareport/report/HDReportService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +17,8 @@ import de.wevsvirushackathon.coronareport.client.ClientRepository;
 
 @Service
 public class HDReportService {
+
+	private final Logger log = LoggerFactory.getLogger(HDReportService.class);
 
 	private ModelMapper modelMapper;
     private ClientRepository clientRepository;
@@ -34,14 +38,13 @@ public class HDReportService {
         List<Client> clients = this.clientRepository.findAllByHealthDepartmentId(healthDepartmentId);
         
         if(clients == null) {
+        	log.info("No clients found for hd: " + healthDepartmentId);
         	return new ArrayList<>();
         }
 
 		return clients.stream().map(client -> {
 
 			HDClient hdClient = modelMapper.map(client, HDClient.class);
-
-
 
 			List<DiaryEntry> diaryEntries =  diaryRepository.findAllByClientOrderByDateTimeDesc(client);
 			hdClient.setDiaryEntires(diaryEntries);
@@ -58,11 +61,7 @@ public class HDReportService {
 
 			determineStatus(hdClient);
 
-
-
-
 			return hdClient;
-
 
 		}).collect(Collectors.toList());
     }


### PR DESCRIPTION
Add more logging statements where appropriate. Suggested approach:
 - Log only what is necessary: The more branches and the more complex an API function is, the more LOG statements it should have. No logging for API functions that only forward & map data to JPA provider
- No "Begin call / End call" statement at the beginning or the end, because it could be captured by TRACE level logging and the information is not that valuable.
- Output is only on STDOUT - as google cloud service seems to handle this well enough