### PR TITLE
creating landing page for different user types

### DIFF
--- a/frontend/src/app/models/report-case.ts
+++ b/frontend/src/app/models/report-case.ts
@@ -15,6 +15,6 @@ export interface ReportCaseDto {
 }
 
 export enum ClientType {
-  index = 'index',
-  contact = 'contact'
+  Index = 'index',
+  Contact = 'contact'
 }

--- a/frontend/src/app/modules/welcome/landing/landing.component.html
+++ b/frontend/src/app/modules/welcome/landing/landing.component.html
@@ -1,0 +1,60 @@
+<mat-card class="form__card--animated">
+    <mat-card-header>
+        <mat-card-title>
+            <h1>Title</h1>
+        </mat-card-title>
+    </mat-card-header>
+    <mat-card-content *ngIf="userType === 'index'">
+        <section>
+            <p>Lorem ipsum dolor sit amet, duo fugit latine docendi ei, ne illud liber praesent per. Mei cu facilis
+                abhorreant, quaeque indoctum scripserit et pro. Ei blandit officiis efficiantur sed, ea pro option
+                concludaturque. Accusata recteque eum eu, vis eu viris assueverit. Recusabo iudicabit appellantur mel
+                ex, illum
+                primis appareat quo ea. Pro stet cibo definitiones ea, vim tale reformidans conclusionemque te. Pericula
+                ullamcorper ad sed.</p>
+            <p>Sea in quidam accommodare, est elitr verterem an. Te qui putent fuisset, ne errem possim sea, eam
+                invenire
+                abhorreant adversarium id. Dico voluptua elaboraret ex eos, est te ceteros mandamus reprimique. Ex vel
+                atqui
+                accommodare concludaturque, sententiae vituperatoribus pri in. Aeque inciderint ad pri.</p>
+            <p>Ne meis euripidis vix. No nostrud adolescens repudiandae mea. Sed enim quodsi cu. Cu docendi assentior
+                mea, ut
+                per elit luptatum probatus, doctus regione vocibus ad ius. Duo ad causae detraxit maluisset. Est an
+                posse
+                scripta adversarium, urbanitas ullamcorper sed at.</p>
+        </section>
+        <mat-card-actions>
+            <button mat-raised-button color="primary" type="button"
+                [routerLink]="['/welcome/register/', clientcode]">Weiter zur
+                Registrierung</button>
+        </mat-card-actions>
+    </mat-card-content>
+    <mat-card-content *ngIf="userType === 'contact'">
+        <section>
+            <p>Lorem ipsum dolor sit amet, partem latine deserunt mei ea, nonumes blandit deterruisset qui te. Has
+                minimum
+                menandri no, an eum diam viderer philosophia, et nam reque iriure qualisque. Graece consequat
+                signiferumque per
+                no, mel elitr voluptaria in. In has elit timeam, qui doming nominavi gloriatur no, soluta primis
+                voluptatibus eu
+                vix. Purto dolores salutandi eam et.</p>
+            <p>Atqui regione tractatos eu vix, et eum tantas deleniti, his esse deterruisset definitiones ex. Tale
+                labore usu
+                id, ex eam case duis elaboraret. Ei quo nobis sensibus, eu eius detraxit praesent mel, qui impetus
+                quaeque
+                invidunt ei. Ipsum sonet fabellas has ea. Ex quo viris elitr honestatis, ei nibh vidisse nam. Quis
+                epicuri
+                luptatum id nam. Vix in vituperata consectetuer, sea verear scripta vivendo ei.</p>
+            <p>His omittam similique rationibus te, cu purto velit vel. Fierent officiis mel in. Et sea minimum
+                salutatus. No
+                affert appetere sea, ea mei prima omnesque vituperata. Eu eam movet impedit petentium, splendide
+                rationibus cum
+                id. Eu everti iracundia scribentur vix, no has posse instructior.</p>
+        </section>
+        <mat-card-actions>
+            <button mat-raised-button color="primary" type="button"
+                [routerLink]="['/welcome/register/', clientcode]">Weiter zur
+                Registrierung</button>
+        </mat-card-actions>
+    </mat-card-content>
+</mat-card>

--- a/frontend/src/app/modules/welcome/landing/landing.component.html
+++ b/frontend/src/app/modules/welcome/landing/landing.component.html
@@ -1,60 +1,80 @@
 <mat-card class="form__card--animated">
-    <mat-card-header>
-        <mat-card-title>
-            <h1>Title</h1>
-        </mat-card-title>
-    </mat-card-header>
-    <mat-card-content *ngIf="userType === 'index'">
-        <section>
-            <p>Lorem ipsum dolor sit amet, duo fugit latine docendi ei, ne illud liber praesent per. Mei cu facilis
-                abhorreant, quaeque indoctum scripserit et pro. Ei blandit officiis efficiantur sed, ea pro option
-                concludaturque. Accusata recteque eum eu, vis eu viris assueverit. Recusabo iudicabit appellantur mel
-                ex, illum
-                primis appareat quo ea. Pro stet cibo definitiones ea, vim tale reformidans conclusionemque te. Pericula
-                ullamcorper ad sed.</p>
-            <p>Sea in quidam accommodare, est elitr verterem an. Te qui putent fuisset, ne errem possim sea, eam
-                invenire
-                abhorreant adversarium id. Dico voluptua elaboraret ex eos, est te ceteros mandamus reprimique. Ex vel
-                atqui
-                accommodare concludaturque, sententiae vituperatoribus pri in. Aeque inciderint ad pri.</p>
-            <p>Ne meis euripidis vix. No nostrud adolescens repudiandae mea. Sed enim quodsi cu. Cu docendi assentior
-                mea, ut
-                per elit luptatum probatus, doctus regione vocibus ad ius. Duo ad causae detraxit maluisset. Est an
-                posse
-                scripta adversarium, urbanitas ullamcorper sed at.</p>
-        </section>
-        <mat-card-actions>
-            <button mat-raised-button color="primary" type="button"
-                [routerLink]="['/welcome/register/', clientcode]">Weiter zur
-                Registrierung</button>
-        </mat-card-actions>
-    </mat-card-content>
-    <mat-card-content *ngIf="userType === 'contact'">
-        <section>
-            <p>Lorem ipsum dolor sit amet, partem latine deserunt mei ea, nonumes blandit deterruisset qui te. Has
-                minimum
-                menandri no, an eum diam viderer philosophia, et nam reque iriure qualisque. Graece consequat
-                signiferumque per
-                no, mel elitr voluptaria in. In has elit timeam, qui doming nominavi gloriatur no, soluta primis
-                voluptatibus eu
-                vix. Purto dolores salutandi eam et.</p>
-            <p>Atqui regione tractatos eu vix, et eum tantas deleniti, his esse deterruisset definitiones ex. Tale
-                labore usu
-                id, ex eam case duis elaboraret. Ei quo nobis sensibus, eu eius detraxit praesent mel, qui impetus
-                quaeque
-                invidunt ei. Ipsum sonet fabellas has ea. Ex quo viris elitr honestatis, ei nibh vidisse nam. Quis
-                epicuri
-                luptatum id nam. Vix in vituperata consectetuer, sea verear scripta vivendo ei.</p>
-            <p>His omittam similique rationibus te, cu purto velit vel. Fierent officiis mel in. Et sea minimum
-                salutatus. No
-                affert appetere sea, ea mei prima omnesque vituperata. Eu eam movet impedit petentium, splendide
-                rationibus cum
-                id. Eu everti iracundia scribentur vix, no has posse instructior.</p>
-        </section>
-        <mat-card-actions>
-            <button mat-raised-button color="primary" type="button"
-                [routerLink]="['/welcome/register/', clientcode]">Weiter zur
-                Registrierung</button>
-        </mat-card-actions>
-    </mat-card-content>
+  <mat-card-header>
+    <mat-card-title>
+      <h1>Title</h1>
+    </mat-card-title>
+  </mat-card-header>
+  <mat-card-content *ngIf="userType === ClientType.Index">
+    <section>
+      <p>
+        index ipsum dolor sit amet, duo fugit latine docendi ei, ne illud liber
+        praesent per. Mei cu facilis abhorreant, quaeque indoctum scripserit et
+        pro. Ei blandit officiis efficiantur sed, ea pro option concludaturque.
+        Accusata recteque eum eu, vis eu viris assueverit. Recusabo iudicabit
+        appellantur mel ex, illum primis appareat quo ea. Pro stet cibo
+        definitiones ea, vim tale reformidans conclusionemque te. Pericula
+        ullamcorper ad sed.
+      </p>
+      <p>
+        Sea in quidam accommodare, est elitr verterem an. Te qui putent fuisset,
+        ne errem possim sea, eam invenire abhorreant adversarium id. Dico
+        voluptua elaboraret ex eos, est te ceteros mandamus reprimique. Ex vel
+        atqui accommodare concludaturque, sententiae vituperatoribus pri in.
+        Aeque inciderint ad pri.
+      </p>
+      <p>
+        Ne meis euripidis vix. No nostrud adolescens repudiandae mea. Sed enim
+        quodsi cu. Cu docendi assentior mea, ut per elit luptatum probatus,
+        doctus regione vocibus ad ius. Duo ad causae detraxit maluisset. Est an
+        posse scripta adversarium, urbanitas ullamcorper sed at.
+      </p>
+    </section>
+    <mat-card-actions>
+      <button
+        mat-raised-button
+        color="primary"
+        type="button"
+        [routerLink]="['/welcome/register/', clientcode]"
+      >
+        Weiter zur Registrierung
+      </button>
+    </mat-card-actions>
+  </mat-card-content>
+  <mat-card-content *ngIf="userType === ClientType.Contact">
+    <section>
+      <p>
+        contact ipsum dolor sit amet, partem latine deserunt mei ea, nonumes
+        blandit deterruisset qui te. Has minimum menandri no, an eum diam
+        viderer philosophia, et nam reque iriure qualisque. Graece consequat
+        signiferumque per no, mel elitr voluptaria in. In has elit timeam, qui
+        doming nominavi gloriatur no, soluta primis voluptatibus eu vix. Purto
+        dolores salutandi eam et.
+      </p>
+      <p>
+        Atqui regione tractatos eu vix, et eum tantas deleniti, his esse
+        deterruisset definitiones ex. Tale labore usu id, ex eam case duis
+        elaboraret. Ei quo nobis sensibus, eu eius detraxit praesent mel, qui
+        impetus quaeque invidunt ei. Ipsum sonet fabellas has ea. Ex quo viris
+        elitr honestatis, ei nibh vidisse nam. Quis epicuri luptatum id nam. Vix
+        in vituperata consectetuer, sea verear scripta vivendo ei.
+      </p>
+      <p>
+        His omittam similique rationibus te, cu purto velit vel. Fierent
+        officiis mel in. Et sea minimum salutatus. No affert appetere sea, ea
+        mei prima omnesque vituperata. Eu eam movet impedit petentium, splendide
+        rationibus cum id. Eu everti iracundia scribentur vix, no has posse
+        instructior.
+      </p>
+    </section>
+    <mat-card-actions>
+      <button
+        mat-raised-button
+        color="primary"
+        type="button"
+        [routerLink]="['/welcome/register/', clientcode]"
+      >
+        Weiter zur Registrierung
+      </button>
+    </mat-card-actions>
+  </mat-card-content>
 </mat-card>

--- a/frontend/src/app/modules/welcome/landing/landing.component.spec.ts
+++ b/frontend/src/app/modules/welcome/landing/landing.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LandingComponent } from './landing.component';
+
+describe('LandingComponent', () => {
+  let component: LandingComponent;
+  let fixture: ComponentFixture<LandingComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LandingComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LandingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/modules/welcome/landing/landing.component.ts
+++ b/frontend/src/app/modules/welcome/landing/landing.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ClientType } from '../../../models/report-case';
+import { ClientType } from '@models/report-case';
 
 @Component({
   selector: 'app-landing',
@@ -8,14 +8,14 @@ import { ClientType } from '../../../models/report-case';
   styleUrls: ['./landing.component.scss']
 })
 export class LandingComponent implements OnInit {
-
-  public userType = ClientType.index.valueOf();
+  public ClientType = ClientType;
+  public userType = ClientType.Index;
   public clientcode: string;
 
   constructor(private router: Router, private route: ActivatedRoute) { }
 
   ngOnInit(): void {
-    this.userType = this.route.snapshot.paramMap.get('usertype') || this.userType;
+    this.userType = this.route.snapshot.paramMap.get('usertype') as ClientType || this.userType;
     this.clientcode = this.route.snapshot.paramMap.get('clientcode');
   }
 }

--- a/frontend/src/app/modules/welcome/landing/landing.component.ts
+++ b/frontend/src/app/modules/welcome/landing/landing.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ClientType } from '../../../models/report-case';
+
+@Component({
+  selector: 'app-landing',
+  templateUrl: './landing.component.html',
+  styleUrls: ['./landing.component.scss']
+})
+export class LandingComponent implements OnInit {
+
+  public userType = ClientType.index.valueOf();
+  public clientcode: string;
+
+  constructor(private router: Router, private route: ActivatedRoute) { }
+
+  ngOnInit(): void {
+    this.userType = this.route.snapshot.paramMap.get('usertype') || this.userType;
+    this.clientcode = this.route.snapshot.paramMap.get('clientcode');
+  }
+}

--- a/frontend/src/app/modules/welcome/welcome-routing.module.ts
+++ b/frontend/src/app/modules/welcome/welcome-routing.module.ts
@@ -4,11 +4,14 @@ import { RouterModule, Routes } from '@angular/router';
 import { RegisterComponent } from './register/register.component';
 import { LoginComponent } from './login/login.component';
 import { IsAuthenticatedGuard } from '@guards/is-authenticated.guard';
+import { LandingComponent } from './landing/landing.component';
 
 const routes: Routes = [
-  { path: 'register', component: RegisterComponent },
   { path: 'register/:clientcode', component: RegisterComponent },
+  { path: 'register', component: RegisterComponent },
   { path: 'login', component: LoginComponent },
+  { path: 'landing/:usertype/:clientcode', component: LandingComponent },
+  { path: 'landing', component: LandingComponent },
   { path: '', component: WelcomeComponent, canActivate: [IsAuthenticatedGuard] }
 ];
 

--- a/frontend/src/app/modules/welcome/welcome.component.html
+++ b/frontend/src/app/modules/welcome/welcome.component.html
@@ -1,17 +1,10 @@
-<mat-card
-  class="form__card--small form__card--animated"
-  style="margin-bottom: 1rem; text-align: center; color: red;"
->
+<mat-card class="form__card--small form__card--animated mb-3 text-center" style="color: red;">
   <span style="margin-left: 1rem;">
     Im Falle eines medizinischen Notfalls wählen Sie bitte umgehend den Notruf
   </span>
 </mat-card>
 
-<mat-card
-  class="form__card--small form__card--animated"
-  style="margin-bottom: 1rem; text-align: center;"
-  id="info-card"
->
+<mat-card class="form__card--small form__card--animated mb-3 text-center" id="info-card">
   <div class="marquee">
     <p class="info-text">
       Dieser Prototyp dient lediglich zu Demonstrationszwecken und ist NICHT an
@@ -20,5 +13,3 @@
     </p>
   </div>
 </mat-card>
-
-<h2 class="text-center">Landing page will go here</h2>

--- a/frontend/src/app/modules/welcome/welcome.module.ts
+++ b/frontend/src/app/modules/welcome/welcome.module.ts
@@ -9,6 +9,7 @@ import { MatStepperModule } from '@angular/material/stepper';
 import { RegisterComponent } from './register/register.component';
 import { LoginComponent } from './login/login.component';
 import { MAT_DATE_FORMATS } from '@angular/material/core';
+import { LandingComponent } from './landing/landing.component';
 
 export const DATE_FORMAT = {
   parse: {
@@ -27,7 +28,8 @@ export const DATE_FORMAT = {
   declarations: [
     WelcomeComponent,
     RegisterComponent,
-    LoginComponent
+    LoginComponent,
+    LandingComponent
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -91,8 +91,8 @@ export class ApiService {
   }
 
   getCases(): Observable<Array<ReportCaseDto>> {
-    return this.httpClient.get<any[]>(`${this.baseUrl}/api/hd/cases`)
-      .pipe(share(), map(result => result.map(item => this.mapReportCase(item))));
+    return this.httpClient.get<any>(`${this.baseUrl}/api/hd/cases`)
+      .pipe(share(), map(result => result._embedded.cases.map(item => this.mapReportCase(item))));
   }
 
   getDiary(): Observable<DiaryDto> {


### PR DESCRIPTION
This landing page will be shown to the different user types when they
first visit the quarano app via the registration link of the
local health authority.
Depending on the type of user the text will differ and the call to action
button will lead the user to different entry points.
Furthermore, the registration code will be passed to the registration
page to pre-fill the form accordingly.

In this PR the feedback from PR #26 was applied. If this is merged, feature/CORE-54 can be deleted.