### PR TITLE
Review database scheme and provide migrations via flyway.

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,6 +63,10 @@
 			<artifactId>spring-boot-devtools</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>

--- a/backend/src/main/java/quarano/actions/ActionItem.java
+++ b/backend/src/main/java/quarano/actions/ActionItem.java
@@ -27,21 +27,26 @@ import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 import java.io.Serializable;
 import java.util.UUID;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 
 /**
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Entity
+@Table(name = "action_items")
 @Getter
 @NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
 public abstract class ActionItem extends QuaranoAggregate<ActionItem, ActionItemIdentifier> {
 
-	private TrackedPersonIdentifier personIdentifier;
-	private ItemType type;
+	private @AttributeOverride(name = "trackedPersonId", column = @Column(name = "tracked_person_id")) TrackedPersonIdentifier personIdentifier;
+	private @Column(name = "item_type") ItemType type;
 	private Description description;
 	private boolean resolved;
 
@@ -100,6 +105,8 @@ public abstract class ActionItem extends QuaranoAggregate<ActionItem, ActionItem
 	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 	public static class ActionItemIdentifier implements Identifier, Serializable {
 		private static final long serialVersionUID = 7871473225101042167L;
-		final UUID departmentId;
+		
+		@Column(name = "ifd")
+		final UUID actionItemId;
 	}
 }

--- a/backend/src/main/java/quarano/auth/Account.java
+++ b/backend/src/main/java/quarano/auth/Account.java
@@ -18,10 +18,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToMany;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.springframework.lang.Nullable;
@@ -31,8 +34,10 @@ import org.springframework.lang.Nullable;
  * HD employee account
  *
  * @author Patrick Otto
+ * @author Michael J. Simons
  */
 @Entity
+@Table(name = "accounts")
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Account extends QuaranoAggregate<Account, AccountIdentifier> implements AccountInfo {
 
@@ -42,10 +47,10 @@ public class Account extends QuaranoAggregate<Account, AccountIdentifier> implem
 	@Getter private String firstname;
 	@Getter private String lastname;
 
-	@Getter private DepartmentIdentifier departmentId;
+	@Getter @AttributeOverride(name = "departmentId", column = @Column(name = "departement_id")) private DepartmentIdentifier departmentId;
 
 	// will be null if account belongs to a health department employee
-	@Getter private @Nullable TrackedPersonIdentifier trackedPersonId;
+	@Getter private @Nullable @AttributeOverride(name = "trackedPersonId", column = @Column(name = "tracked_person_id")) TrackedPersonIdentifier trackedPersonId;
 
 	@ManyToMany(fetch = FetchType.EAGER) //
 	@Getter private List<Role> roles = new ArrayList<>();
@@ -112,7 +117,8 @@ public class Account extends QuaranoAggregate<Account, AccountIdentifier> implem
 	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 	public static class AccountIdentifier implements Identifier, Serializable {
 		private static final long serialVersionUID = 7871473225101042167L;
-		final UUID accountId;
+
+		final @Column(name = "id") UUID accountId;
 	}
 
 	public boolean isTrackedPerson() {

--- a/backend/src/main/java/quarano/auth/ActivationCode.java
+++ b/backend/src/main/java/quarano/auth/ActivationCode.java
@@ -15,21 +15,25 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 
 @Entity
+@Table(name = "activation_codes")
 @EqualsAndHashCode(callSuper = true, of = {})
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class ActivationCode extends QuaranoAggregate<ActivationCode, ActivationCodeIdentifier> {
 
 	private @Getter LocalDateTime expirationTime;
-	private @Getter TrackedPersonIdentifier trackedPersonId;
+	private @Getter @AttributeOverride(name = "trackedPersonId", column = @Column(name = "tracked_person_id")) TrackedPersonIdentifier trackedPersonId;
 	private @Getter ActivationCodeStatus status;
 	private @Getter int activationTries;
-	private @Getter DepartmentIdentifier departmentId;
+	private @Getter @AttributeOverride(name = "departmentId", column = @Column(name = "departement_id")) DepartmentIdentifier departmentId;
 
 	public ActivationCode(LocalDateTime expirationTime, TrackedPersonIdentifier trackedPersonId,
 			DepartmentIdentifier departmentId) {
@@ -108,11 +112,13 @@ public class ActivationCode extends QuaranoAggregate<ActivationCode, ActivationC
 	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 	public static class ActivationCodeIdentifier implements Identifier, Serializable {
 		private static final long serialVersionUID = 7871473225101042167L;
-		final UUID id;
+		
+		@Column(name = "id")
+		final UUID activationCodeId;
 
 		@Override
 		public String toString() {
-			return id.toString();
+			return activationCodeId.toString();
 		}
 	}
 

--- a/backend/src/main/java/quarano/auth/Role.java
+++ b/backend/src/main/java/quarano/auth/Role.java
@@ -1,8 +1,26 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package quarano.auth;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 import lombok.NoArgsConstructor;
 
@@ -10,15 +28,18 @@ import lombok.NoArgsConstructor;
 /**
  * A masterdata-entity, which can be assigned to an account.
  * @author Patrick Otto
+ * @author Michael J. Simons
  *
  */
 @Entity
+@Table(name = "roles")
 @NoArgsConstructor
 public class Role {
 	
-    @Id
-    @GeneratedValue
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private int id;
+	@Column(name = "role_name")
 	private String name;
 	
 	public Role(RoleType name){

--- a/backend/src/main/java/quarano/department/Comment.java
+++ b/backend/src/main/java/quarano/department/Comment.java
@@ -28,16 +28,20 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.springframework.util.Assert;
 
 /**
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Entity
+@Table(name = "comments")
 @Getter
 @EqualsAndHashCode(callSuper = true, of = {})
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
@@ -45,8 +49,9 @@ public class Comment extends QuaranoEntity<TrackedCase, CommentIdentifier> imple
 
 	public static final Comparator<Comment> BY_DATE_DESCENDING = Comparator.comparing(Comment::getDate);
 
-	private LocalDateTime date;
-	private String comment;
+	private @Column(name = "comment_date") LocalDateTime date;
+	
+	private @Column(name = "comment_text") String comment;
 	private String author;
 
 	public Comment(String comment, String author) {
@@ -77,11 +82,11 @@ public class Comment extends QuaranoEntity<TrackedCase, CommentIdentifier> imple
 
 		private static final long serialVersionUID = 7871473225101042167L;
 
-		final UUID departmentId;
+		final @Column(name = "id") UUID commentId;
 
 		@Override
 		public String toString() {
-			return departmentId.toString();
+			return commentId.toString();
 		}
 	}
 }

--- a/backend/src/main/java/quarano/department/Department.java
+++ b/backend/src/main/java/quarano/department/Department.java
@@ -29,17 +29,20 @@ import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 
 /**
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Entity
+@Table(name = "departments")
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Department extends QuaranoAggregate<Department, DepartmentIdentifier> {
 
-	private final @Getter @Column(unique = true) String name;
+	private final @Getter @Column(name = "department_name", unique = true) String name;
 
 	public Department(String name) {
 		this(name, UUID.randomUUID());
@@ -62,6 +65,8 @@ public class Department extends QuaranoAggregate<Department, DepartmentIdentifie
 	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 	public static class DepartmentIdentifier implements Identifier, Serializable {
 		private static final long serialVersionUID = 7871473225101042167L;
+		
+		@Column(name = "id")
 		final UUID departmentId;
 
 		@Override

--- a/backend/src/main/java/quarano/department/DepartmentDataInitializer.java
+++ b/backend/src/main/java/quarano/department/DepartmentDataInitializer.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-@Order(510)
+@Order(490)
 @Slf4j
 public class DepartmentDataInitializer implements DataInitializer {
 

--- a/backend/src/main/java/quarano/department/InitialReport.java
+++ b/backend/src/main/java/quarano/department/InitialReport.java
@@ -32,14 +32,17 @@ import java.util.UUID;
 
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Entity
+@Table(name = "initial_reports")
 @Data
 @EqualsAndHashCode(callSuper = true, of = {})
 @Setter(AccessLevel.PACKAGE)

--- a/backend/src/main/java/quarano/department/TrackedCase.java
+++ b/backend/src/main/java/quarano/department/TrackedCase.java
@@ -38,11 +38,13 @@ import java.util.List;
 import java.util.UUID;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.jddd.event.types.DomainEvent;
@@ -51,8 +53,10 @@ import org.springframework.util.Assert;
 
 /**
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Entity
+@Table(name = "tracked_cases")
 @Data
 @Setter(AccessLevel.PACKAGE)
 @EqualsAndHashCode(callSuper = true, of = {})
@@ -66,7 +70,7 @@ public class TrackedCase extends QuaranoAggregate<TrackedCase, TrackedCaseIdenti
 	private InitialReport initialReport;
 
 	@Setter(AccessLevel.NONE) private Enrollment enrollment = new Enrollment();
-	private @Getter @Setter CaseType type = CaseType.INDEX;
+	private @Column(name = "case_type") @Getter @Setter CaseType type = CaseType.INDEX;
 	private @Getter @Setter Quarantine quarantine = null;
 	private @Getter @Setter LocalDate testDate;
 

--- a/backend/src/main/java/quarano/reference/Symptom.java
+++ b/backend/src/main/java/quarano/reference/Symptom.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package quarano.reference;
 
 import lombok.AccessLevel;
@@ -7,15 +22,18 @@ import lombok.Setter;
 
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.PostLoad;
 import javax.persistence.PrePersist;
+import javax.persistence.Table;
 import javax.persistence.Transient;
 
 import org.springframework.data.domain.Persistable;
 
 @Entity
+@Table(name = "symptoms")
 @AllArgsConstructor
 @Getter
 @Setter(value = AccessLevel.PACKAGE)
@@ -24,6 +42,7 @@ public class Symptom implements Persistable<UUID> {
 	@Id //
 	private UUID id;
 	private @Transient boolean isNew = true;
+	@Column(name = "symptom_name")
 	private String name;
 	private boolean isCharacteristic;
 

--- a/backend/src/main/java/quarano/tracking/BodyTemperature.java
+++ b/backend/src/main/java/quarano/tracking/BodyTemperature.java
@@ -17,10 +17,10 @@ package quarano.tracking;
 
 import io.jsonwebtoken.lang.Assert;
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.Locale;
 
 import javax.persistence.Column;
@@ -31,6 +31,7 @@ import org.springframework.util.NumberUtils;
 
 /**
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Embeddable
 @RequiredArgsConstructor(staticName = "of")
@@ -39,8 +40,12 @@ public class BodyTemperature {
 
 	private static final Range<Float> VALID = Range.open(35.0f, 42.0f);
 
-	@Column(name = "temperature") //
-	private final @Getter float value;
+	@Column(name = "temperature", precision = 5, scale = 3) //
+	private final BigDecimal value;
+	
+	public static BodyTemperature of(float value) {
+		return new BodyTemperature(BigDecimal.valueOf(value));
+	}
 
 	/**
 	 * Returns whether the current {@link BodyTemperature} exceeds the given one.
@@ -52,7 +57,7 @@ public class BodyTemperature {
 
 		Assert.notNull(that, "BodyTemperature must not be null!");
 
-		return this.value > that.value;
+		return this.value.compareTo(that.value) >= 1;
 	}
 
 	public static boolean isValid(float value) {
@@ -70,7 +75,11 @@ public class BodyTemperature {
 
 		Assert.hasText(source, "No body temperature source value given!");
 
-		return new BodyTemperature(NumberUtils.parseNumber(source, Float.class));
+		return BodyTemperature.of(NumberUtils.parseNumber(source, Float.class));
+	}
+
+	public float getValue() {
+		return this.value.floatValue();
 	}
 
 	/*
@@ -79,6 +88,6 @@ public class BodyTemperature {
 	 */
 	@Override
 	public String toString() {
-		return String.format(Locale.GERMAN, "%.1f°C", value);
+		return String.format(Locale.GERMAN, "%.1f°C", value.floatValue());
 	}
 }

--- a/backend/src/main/java/quarano/tracking/ContactPerson.java
+++ b/backend/src/main/java/quarano/tracking/ContactPerson.java
@@ -35,6 +35,7 @@ import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.jddd.event.types.DomainEvent;
@@ -43,6 +44,7 @@ import org.jddd.event.types.DomainEvent;
  * @author Oliver Drotbohm
  */
 @Entity(name = "newContactPerson")
+@Table(name = "new_contact_people")
 @Data
 @EqualsAndHashCode(callSuper = true, of = {})
 @Accessors(chain = true)
@@ -64,7 +66,7 @@ public class ContactPerson extends QuaranoAggregate<ContactPerson, ContactPerson
 	private @Getter @Setter Boolean isSenior;
 	private @Getter @Setter Boolean hasPreExistingConditions;
 	
-	private @Column(nullable = false) TrackedPersonIdentifier ownerId;
+	private @Column(nullable = false) @AttributeOverride(name = "trackedPersonId", column = @Column(name = "tracked_person_id")) TrackedPersonIdentifier ownerId;
 
 	public ContactPerson(String firstName, String lastName, ContactWays contactWays) {
 

--- a/backend/src/main/java/quarano/tracking/DiaryEntry.java
+++ b/backend/src/main/java/quarano/tracking/DiaryEntry.java
@@ -37,10 +37,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.ManyToMany;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.jddd.event.types.DomainEvent;
@@ -50,9 +52,11 @@ import org.springframework.util.Assert;
  * A bi-daily diary entry capturing a report of medical conditions and potential {@link ContactPerson}s.
  *
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @EqualsAndHashCode(callSuper = true, of = {})
 @Entity
+@Table(name = "diary_entries")
 @Accessors(chain = true)
 @Data
 @AllArgsConstructor
@@ -67,7 +71,7 @@ public class DiaryEntry extends QuaranoAggregate<DiaryEntry, DiaryEntryIdentifie
 	private @ManyToMany List<Symptom> symptoms = new ArrayList<>();
 	private String note;
 	private BodyTemperature bodyTemperature;
-	private TrackedPersonIdentifier trackedPersonId;
+	private @AttributeOverride(name = "trackedPersonId", column = @Column(name = "tracked_person_id")) TrackedPersonIdentifier trackedPersonId;
 
 	DiaryEntry(Slot slot, TrackedPersonIdentifier id) {
 		this(DiaryEntryIdentifier.of(UUID.randomUUID()), id, LocalDateTime.now(), slot);

--- a/backend/src/main/java/quarano/tracking/Encounter.java
+++ b/backend/src/main/java/quarano/tracking/Encounter.java
@@ -19,9 +19,11 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.springframework.util.Assert;
@@ -37,13 +39,15 @@ import quarano.tracking.Encounter.EncounterIdentifier;
 
 /**
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Entity
+@Table(name = "encounters")
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Encounter extends QuaranoEntity<TrackedPerson, EncounterIdentifier> {
 
 	private final @Getter @ManyToOne ContactPerson contact;
-	private final @Getter LocalDate date;
+	private final @Column(name = "encounter_date")@Getter LocalDate date;
 
 	private Encounter(ContactPerson contact, LocalDate date) {
 
@@ -77,6 +81,6 @@ public class Encounter extends QuaranoEntity<TrackedPerson, EncounterIdentifier>
 	@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 	public static class EncounterIdentifier implements Identifier, Serializable {
 		private static final long serialVersionUID = -5998761917714158567L;
-		private final UUID encounterId;
+		private final @Column(name = "id") UUID encounterId;
 	}
 }

--- a/backend/src/main/java/quarano/tracking/Slot.java
+++ b/backend/src/main/java/quarano/tracking/Slot.java
@@ -27,17 +27,19 @@ import java.time.LocalTime;
 import java.time.temporal.TemporalAmount;
 import java.util.Arrays;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 import org.springframework.util.Assert;
 
 /**
- * Represents a time slot, a {@link DiaryEntry} is assigned to and lives in. I consists of a date and a
+ * Represents a time slot, a {@link DiaryEntry} is assigned to and lives in. It consists of a date and a
  * {@link TimeOfDay} that covers certain time spans (6am-4pm, 4pm-6am). Interesting about esp. the latter period is that
  * e.g. the Slot for e.g. 2am of a day is the evening slot of the day before. {@link Slot#of(LocalDateTime)} correctly
  * considers this.
  *
  * @author Oliver Drotbohm
+ * @author Michael J. Simons
  */
 @Embeddable
 @Getter
@@ -46,7 +48,7 @@ import org.springframework.util.Assert;
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Slot {
 
-	private final LocalDate date;
+	private final @Column(name = "date_of_slot") LocalDate date;
 	private final TimeOfDay timeOfDay;
 
 	/**

--- a/backend/src/main/java/quarano/tracking/TrackedPerson.java
+++ b/backend/src/main/java/quarano/tracking/TrackedPerson.java
@@ -43,6 +43,7 @@ import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 import javax.persistence.PostLoad;
+import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
 import org.jddd.event.types.DomainEvent;
@@ -54,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Patrick Otto
  */
 @Entity
+@Table(name = "tracked_people")
 @Accessors(chain = true)
 @AllArgsConstructor
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
@@ -203,6 +205,7 @@ public class TrackedPerson extends QuaranoAggregate<TrackedPerson, TrackedPerson
 
 		private static final long serialVersionUID = -853047182358126916L;
 
+		@Column(name = "id")
 		private final UUID trackedPersonId;
 
 		@Override

--- a/backend/src/main/resources/application-develop.properties
+++ b/backend/src/main/resources/application-develop.properties
@@ -7,6 +7,7 @@ spring.datasource.password=AcHC85AthIG93PL2
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 
 # Hibernate ddl auto (create, create-drop, validate, update)
-spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.ddl-auto = validate
+spring.jpa.generate-ddl = false
 
 logging.level.quarano=INFO

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -7,4 +7,5 @@ spring.datasource.password=AcHC85AthIG93PL2
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 
 # Hibernate ddl auto (create, create-drop, validate, update)
-spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.ddl-auto = validate
+spring.jpa.generate-ddl = false

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,7 +7,8 @@
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 
 # Hibernate ddl auto (create, create-drop, validate, update)
-spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.ddl-auto = validate
+spring.jpa.generate-ddl = false
 
 # JSON Marshalling
 spring.jackson.generator.escape-non-ascii=true

--- a/backend/src/main/resources/db/migration/V0000__Create_initial_schema.sql
+++ b/backend/src/main/resources/db/migration/V0000__Create_initial_schema.sql
@@ -1,0 +1,240 @@
+CREATE TABLE accounts (
+	id uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	departement_id uuid NULL,
+	firstname varchar(255) NULL,
+	lastname varchar(255) NULL,
+	value varchar(255) NULL,
+	tracked_person_id uuid NULL,
+	username varchar(255) NULL,
+	CONSTRAINT accounts_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE activation_codes (
+	id uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	activation_tries integer NOT NULL,
+	departement_id uuid NULL,
+	expiration_time timestamp NULL,
+	status integer NULL,
+	tracked_person_id uuid NULL,
+	CONSTRAINT activation_codes_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE comments (
+	id uuid NOT NULL,
+	author varchar(255) NULL,
+	comment_text varchar(255) NULL,
+	comment_date timestamp NULL,
+	CONSTRAINT comments_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE departments (
+	id uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	department_name varchar(255) NULL,
+	CONSTRAINT departments_pkey PRIMARY KEY (id),
+	CONSTRAINT uk_qyf2ekbfpnddm6f3rkgt39i9o UNIQUE (department_name)
+);
+
+
+CREATE TABLE diary_entries (
+	id uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	temperature numeric(5,3) null,
+	note varchar(255) NULL,
+	reported_at timestamp NULL,
+	date_of_slot date NULL,
+	time_of_day integer NULL,
+	tracked_person_id uuid NULL,
+	CONSTRAINT diary_entries_pkey PRIMARY KEY (id)
+);
+
+
+CREATE TABLE initial_reports (
+	id uuid NOT NULL,
+	belong_to_laboratory_staff bool NULL,
+	belong_to_medical_staff bool NULL,
+	belong_to_nursing_staff bool NULL,
+	day_of_first_symptoms date NULL,
+	direct_contact_with_liquids_ofc19pat bool NULL,
+	family_member bool NULL,
+	flight_crew_member_withc19pat bool NULL,
+	flight_passenger_close_rowc19pat bool NULL,
+	has_symptoms bool NULL,
+	min15minutes_contact_withc19pat bool NULL,
+	nursing_action_onc19pat bool NULL,
+	other_contact_type varchar(255) NULL,
+	CONSTRAINT initial_reports_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE new_contact_people (
+	id uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	city varchar(255) NULL,
+	house_number varchar(255) NULL,
+	street varchar(255) NULL,
+	zipcode varchar(255) NULL,
+	email varchar(255) NULL,
+	first_name varchar(255) NULL,
+	has_pre_existing_conditions bool NULL,
+	identification_hint varchar(255) NULL,
+	is_health_staff bool NULL,
+	is_senior bool NULL,
+	last_name varchar(255) NULL,
+	mobile_phone_number varchar(255) NULL,
+	tracked_person_id uuid NULL,
+	phone_number varchar(255) NULL,
+	remark varchar(255) NULL,
+	type_of_contract integer NULL,
+	CONSTRAINT new_contact_people_pkey PRIMARY KEY (id)
+);
+
+
+CREATE TABLE roles (
+	id serial NOT NULL,
+	role_name varchar(255) NULL,
+	CONSTRAINT roles_pkey PRIMARY KEY (id)
+);
+
+
+CREATE TABLE symptoms (
+	id uuid NOT NULL,
+	is_characteristic bool NOT NULL,
+	symptom_name varchar(255) NULL,
+	CONSTRAINT symptoms_pkey PRIMARY KEY (id)
+);
+
+
+CREATE TABLE tracked_people (
+	id uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	account_registered_at timestamp NULL,
+	city varchar(255) NULL,
+	house_number varchar(255) NULL,
+	street varchar(255) NULL,
+	zipcode varchar(255) NULL,
+	date_of_birth date NULL,
+	email varchar(255) NULL,
+	first_name varchar(255) NULL,
+	last_name varchar(255) NULL,
+	mobile_phone_number varchar(255) NULL,
+	phone_number varchar(255) NULL,
+	CONSTRAINT tracked_people_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE accounts_roles (
+	account_id uuid NOT NULL,
+	roles_id integer NOT NULL,
+	CONSTRAINT accounts_roles_account_fk FOREIGN KEY (roles_id) REFERENCES roles(id),
+	CONSTRAINT accounts_roles_role_fk FOREIGN KEY (account_id) REFERENCES accounts(id)
+);
+
+CREATE TABLE action_items (
+	dtype varchar(31) NOT NULL,
+	ifd uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	arguments varchar(255) NULL,
+	code integer NULL,
+	tracked_person_id uuid NULL,
+	resolved bool NOT NULL,
+	item_type integer NULL,
+	date_of_slot date NULL,
+	time_of_day integer NULL,
+	id uuid NULL,
+	entry_id uuid NULL,
+	CONSTRAINT action_items_pkey PRIMARY KEY (ifd),
+	CONSTRAINT action_items_diary_entries_fk FOREIGN KEY (entry_id) REFERENCES diary_entries(id)
+);
+
+
+CREATE TABLE diary_entries_contacts (
+	diary_entry_id uuid NOT NULL,
+	contacts_id uuid NOT NULL,
+	CONSTRAINT diary_entries_contacts_contact_person_fk FOREIGN KEY (contacts_id) REFERENCES new_contact_people(id),
+	CONSTRAINT diary_entries_contacts_diary_entry_fk FOREIGN KEY (diary_entry_id) REFERENCES diary_entries(id)
+);
+
+CREATE TABLE diary_entries_symptoms (
+	diary_entry_id uuid NOT NULL,
+	symptoms_id uuid NOT NULL,
+	CONSTRAINT diary_entries_symptoms_diary_entries_fk FOREIGN KEY (diary_entry_id) REFERENCES diary_entries(id),
+	CONSTRAINT diary_entries_symptoms_symptons_fk FOREIGN KEY (symptoms_id) REFERENCES symptoms(id)
+);
+
+CREATE TABLE encounters (
+	id uuid NOT NULL,
+	encounter_date date NULL,
+	contact_id uuid NULL,
+	CONSTRAINT encounters_pkey PRIMARY KEY (id),
+	CONSTRAINT encounters_contact_person_fk FOREIGN KEY (contact_id) REFERENCES new_contact_people(id)
+);
+
+CREATE TABLE tracked_cases (
+	id uuid NOT NULL,
+	created timestamp NULL,
+	created_by uuid NULL,
+	last_modified timestamp NULL,
+	last_modified_by uuid NULL,
+	concluded bool NOT NULL,
+	completed_contact_retro bool NOT NULL,
+	completed_personal_data bool NOT NULL,
+	completed_questionnaire bool NOT NULL,
+	infected bool NOT NULL,
+	quarantine_from date NULL,
+	quarantine_to date NULL,
+	test_date date NULL,
+	case_type integer NULL,
+	department_id uuid NULL,
+	initial_report_id uuid NULL,
+	tracked_person_id uuid NULL,
+	CONSTRAINT tracked_cases_pkey PRIMARY KEY (id),
+	CONSTRAINT tracked_cases_department_fk FOREIGN KEY (department_id) REFERENCES departments(id),
+	CONSTRAINT tracked_cases_initial_report_fk FOREIGN KEY (initial_report_id) REFERENCES initial_reports(id),
+	CONSTRAINT tracked_cases_tracked_person_fk FOREIGN KEY (tracked_person_id) REFERENCES tracked_people(id)
+);
+
+CREATE TABLE tracked_cases_comments (
+	tracked_case_id uuid NOT NULL,
+	comments_id uuid NOT NULL,
+	CONSTRAINT uk_flu8g0pcj8opppsxwlxpp8a8h UNIQUE (comments_id),
+	CONSTRAINT tracked_cases_comments_tracked_case_id FOREIGN KEY (tracked_case_id) REFERENCES tracked_cases(id),
+	CONSTRAINT tracked_cases_comments_comment_id FOREIGN KEY (comments_id) REFERENCES comments(id)
+);
+
+CREATE TABLE tracked_cases_origin_contacts (
+	tracked_case_id uuid NOT NULL,
+	origin_contacts_id uuid NOT NULL,
+	CONSTRAINT uk_5w3qfxyw7sumuhsejtngstp6u UNIQUE (origin_contacts_id),
+	CONSTRAINT tracked_cases_origin_contacts_contact_person_fk FOREIGN KEY (origin_contacts_id) REFERENCES new_contact_people(id),
+	CONSTRAINT tracked_cases_origin_contacts_tracked_case_fk FOREIGN KEY (tracked_case_id) REFERENCES tracked_cases(id)
+);
+
+CREATE TABLE tracked_people_encounters (
+	tracked_person_id uuid NOT NULL,
+	encounters_id uuid NOT NULL,
+	CONSTRAINT uk_hhc907fk7ogq8emu5jjtr43rd UNIQUE (encounters_id),
+	CONSTRAINT tracked_people_encounters_encounter_fk FOREIGN KEY (encounters_id) REFERENCES encounters(id),
+	CONSTRAINT tracked_people_encounters_tracked_person_fk FOREIGN KEY (tracked_person_id) REFERENCES tracked_people(id)
+);

--- a/backend/src/main/resources/db/migration/V0001__Add_additional_indexes.sql
+++ b/backend/src/main/resources/db/migration/V0001__Add_additional_indexes.sql
@@ -1,0 +1,11 @@
+ALTER TABLE accounts ADD CONSTRAINT accounts_department_fk FOREIGN KEY (departement_id) REFERENCES departments (id);
+ALTER TABLE accounts ADD CONSTRAINT accounts_tracked_person_fk FOREIGN KEY (tracked_person_id) REFERENCES tracked_people (id);
+
+ALTER TABLE activation_codes ADD CONSTRAINT activation_codes_department_fk FOREIGN KEY (departement_id) REFERENCES departments (id);
+ALTER TABLE activation_codes ADD CONSTRAINT activation_codes_tracked_person_fk FOREIGN KEY (tracked_person_id) REFERENCES tracked_people (id);
+
+ALTER TABLE diary_entries ADD CONSTRAINT diary_entries_tracked_person_fk FOREIGN KEY (tracked_person_id) REFERENCES tracked_people (id);
+
+ALTER TABLE new_contact_people ADD CONSTRAINT new_contact_people_tracked_person_fk FOREIGN KEY (tracked_person_id) REFERENCES tracked_people (id);
+
+ALTER TABLE action_items ADD CONSTRAINT action_items_tracked_person_fk FOREIGN KEY (tracked_person_id) REFERENCES tracked_people (id);


### PR DESCRIPTION
As discussed with @odrotbohm yesterday. This reviews and changes the entity definitions in that regard that the resulting database scheme is more human readable.

This requires a bit of effort with the domain object identifier. As the project uses them to relate entities without creating for example `@OneToMany` or any other association JPA likes, they would lead to duplicate columns due to the change to have all primary id columns named `Id`.

However, I think the change is necessary, especially in that regard. As some of the identifier had irritating names (I guess due to Copy & Paste), one would end up with a database model that is very confusing to look at.

Apart from that, the 2nd big change is the moving from `float` to `BigDecimal` in the `BodyTemperature`. Hibernate is unable to accept the fact that H2 will create a SQL `real` as `real` and Postgres will replace it with `float4`. With `float` as attribute type, there's no `columnDefinition` in `@Column` that is able to make both H2 and Postgres validate by Hibernate as long as Hibernate itself doesn't generate that scheme.

I hope you find this PR useful. 

I think it provides value as the database scheme can be reused without the application and hibernate in a better way. 