### PR TITLE
add cypress tests for landing page

### DIFF
--- a/frontend/cypress/integration/client/landing.ts
+++ b/frontend/cypress/integration/client/landing.ts
@@ -1,0 +1,38 @@
+/// <reference types="cypress" />
+
+describe('landing page', () => {
+    const clientCode = 'af12bd44-70b3-44f1-82d6-79bfd31dd4f4';
+    beforeEach(() => {
+        cy.server();
+    });
+
+    describe('correct content is shown', () => {
+        it('index person', () => {
+            cy.visit(`http://localhost:4200/welcome/landing/index/${clientCode}`);
+            cy.get('[data-cy="cta-button-index"]').should('exist');
+            cy.get('[data-cy="cta-button-contact"]').should('not.exist');
+        });
+
+        it('contact person', () => {
+            cy.visit(`http://localhost:4200/welcome/landing/contact/${clientCode}`);
+            cy.get('[data-cy="cta-button-index"]').should('not.exist');
+            cy.get('[data-cy="cta-button-contact"]').should('exist');
+        });
+    });
+
+    describe('user is directed to the right page with correct client code', () => {
+        it('index person', () => {
+            cy.visit(`http://localhost:4200/welcome/landing/index/${clientCode}`);
+            cy.get('[data-cy="cta-button-index"]').click();
+            cy.url().should('include', `/welcome/register/${clientCode}`);
+            cy.get('[data-cy="input-client-code"] input[matInput]').should('exist').should('have.value', clientCode);
+        });
+
+        it('contact person', () => {
+            cy.visit(`http://localhost:4200/welcome/landing/contact/${clientCode}`);
+            cy.get('[data-cy="cta-button-contact"]').click();
+            cy.url().should('include', `/welcome/register/${clientCode}`);
+            cy.get('[data-cy="input-client-code"] input[matInput]').should('exist').should('have.value', clientCode);
+        });
+    });
+});

--- a/frontend/src/app/modules/welcome/landing/landing.component.html
+++ b/frontend/src/app/modules/welcome/landing/landing.component.html
@@ -33,7 +33,7 @@
                     die Daten. Bei Fragen sprechen Sie uns gerne an.</em></p>
         </section>
         <mat-card-actions>
-            <button mat-raised-button color="primary" type="button"
+            <button mat-raised-button color="primary" type="button" data-cy="cta-button-index"
                 [routerLink]="['/welcome/register/', clientcode]">WEITER</button>
         </mat-card-actions>
     </mat-card-content>
@@ -73,7 +73,7 @@
                     die Daten. Bei Fragen sprechen Sie uns gerne an.</em></p>
         </section>
         <mat-card-actions>
-            <button mat-raised-button color="primary" type="button" [routerLink]="['/welcome/register/', clientcode]">
+            <button mat-raised-button color="primary" type="button" [routerLink]="['/welcome/register/', clientcode]" data-cy="cta-button-contact">
                 WEITER
             </button>
         </mat-card-actions>


### PR DESCRIPTION
This change adds some cypress tests for the landing pages of index and
contact persons. The tests check if the right content is shown to the
specific users and if they get redirected correctly with their
registration code to the registration page.