### PR TITLE
BUG168: Fixed wrongly positioned mat-error.

### DIFF
--- a/frontend/src/app/modules/basic-data/initial-questionaire-form/initial-questionaire-form.component.html
+++ b/frontend/src/app/modules/basic-data/initial-questionaire-form/initial-questionaire-form.component.html
@@ -1,10 +1,18 @@
 <div class="questionaire-form-container" [formGroup]="formGroup">
-
   <div class="bool-question">
     <mat-label>Haben Sie bei sich bereits Symptome festgestellt?*</mat-label>
-    <mat-radio-group required aria-labelledby="hasSymptomsLabel" class="example-radio-group" formControlName="hasSymptoms">
-      <mat-radio-button class="example-radio-button" [value]="true">Ja</mat-radio-button>
-      <mat-radio-button class="example-radio-button" [value]="false">Nein</mat-radio-button>
+    <mat-radio-group
+      required
+      aria-labelledby="hasSymptomsLabel"
+      class="example-radio-group"
+      formControlName="hasSymptoms"
+    >
+      <mat-radio-button class="example-radio-button" [value]="true"
+        >Ja</mat-radio-button
+      >
+      <mat-radio-button class="example-radio-button" [value]="false"
+        >Nein</mat-radio-button
+      >
     </mat-radio-group>
   </div>
   <div class="question sub-question" *ngIf="formGroup.get('hasSymptoms').value">
@@ -27,7 +35,8 @@
   </div>
   <div class="question sub-question" *ngIf="formGroup.get('hasSymptoms').value">
     <mat-label>Welche Symptome haben Sie bei sich festgestellt?*</mat-label>
-    <app-multiple-autocomplete class="full-width"
+    <app-multiple-autocomplete
+      class="full-width"
       [control]="this.formGroup.controls.symptoms"
       [selectableItems]="symptoms"
       [nameProperties]="['name']"
@@ -37,29 +46,44 @@
   <div class="question">
     <mat-label>Bitte geben Sie Ihren behandelnden Hausarzt an.</mat-label>
     <mat-form-field class="full-width">
-      <input matInput formControlName="familyDoctor"/>
+      <input matInput formControlName="familyDoctor" />
     </mat-form-field>
   </div>
   <div class="question">
-    <mat-label>Nennen Sie uns bitte den (vermuteten) Ort der Ansteckung:</mat-label>
+    <mat-label
+      >Nennen Sie uns bitte den (vermuteten) Ort der Ansteckung:</mat-label
+    >
     <mat-form-field class="full-width">
-      <input matInput formControlName="guessedOriginOfInfection"/>
+      <input matInput formControlName="guessedOriginOfInfection" />
     </mat-form-field>
   </div>
   <div class="bool-question">
-    <mat-label>
-      Haben Sie eine oder mehrere relevante Vorerkrankungen?
-      <mat-icon class="ml-1" style="cursor: pointer;" [matTooltip]="tooltip">info</mat-icon>*
+    <mat-label style="display: flex;">
+      Haben Sie eine oder mehrere relevante Vorerkrankungen?*
+      <mat-icon class="ml-1" style="cursor: pointer;" [matTooltip]="tooltip"
+        >info</mat-icon
+      >
     </mat-label>
     <mat-radio-group required formControlName="hasPreExistingConditions">
-      <mat-radio-button class="example-radio-button" [value]="true">Ja</mat-radio-button>
-      <mat-radio-button class="example-radio-button" [value]="false">Nein</mat-radio-button>
+      <mat-radio-button class="example-radio-button" [value]="true"
+        >Ja</mat-radio-button
+      >
+      <mat-radio-button class="example-radio-button" [value]="false"
+        >Nein</mat-radio-button
+      >
     </mat-radio-group>
   </div>
-  <div class="question sub-question" *ngIf="formGroup.get('hasPreExistingConditions').value">
+  <div
+    class="question sub-question"
+    *ngIf="formGroup.get('hasPreExistingConditions').value"
+  >
     <mat-label>Welche Vorerkrankungen haben Sie?*</mat-label>
     <mat-form-field class="full-width">
-      <input matInput required formControlName="hasPreExistingConditionsDescription"/>
+      <input
+        matInput
+        required
+        formControlName="hasPreExistingConditionsDescription"
+      />
     </mat-form-field>
   </div>
   <div class="bool-question">
@@ -67,14 +91,25 @@
       Arbeiten Sie im medizinischen Umfeld oder in der Pflege?*
     </mat-label>
     <mat-radio-group required formControlName="belongToMedicalStaff">
-      <mat-radio-button class="example-radio-button" [value]="true">Ja</mat-radio-button>
-      <mat-radio-button class="example-radio-button" [value]="false">Nein</mat-radio-button>
+      <mat-radio-button class="example-radio-button" [value]="true"
+        >Ja</mat-radio-button
+      >
+      <mat-radio-button class="example-radio-button" [value]="false"
+        >Nein</mat-radio-button
+      >
     </mat-radio-group>
   </div>
-  <div class="question sub-question" *ngIf="formGroup.get('belongToMedicalStaff').value">
+  <div
+    class="question sub-question"
+    *ngIf="formGroup.get('belongToMedicalStaff').value"
+  >
     <mat-label>Wo arbeiten Sie?*</mat-label>
     <mat-form-field class="full-width">
-      <input matInput required formControlName="belongToMedicalStaffDescription"/>
+      <input
+        matInput
+        required
+        formControlName="belongToMedicalStaffDescription"
+      />
     </mat-form-field>
   </div>
   <div class="bool-question">
@@ -82,14 +117,25 @@
       Haben Sie Kontakt zu Risikopersonen?*
     </mat-label>
     <mat-radio-group required formControlName="hasContactToVulnerablePeople">
-      <mat-radio-button class="example-radio-button" [value]="true">Ja</mat-radio-button>
-      <mat-radio-button class="example-radio-button" [value]="false">Nein</mat-radio-button>
+      <mat-radio-button class="example-radio-button" [value]="true"
+        >Ja</mat-radio-button
+      >
+      <mat-radio-button class="example-radio-button" [value]="false"
+        >Nein</mat-radio-button
+      >
     </mat-radio-group>
   </div>
-  <div class="question sub-question" *ngIf="formGroup.get('hasContactToVulnerablePeople').value">
+  <div
+    class="question sub-question"
+    *ngIf="formGroup.get('hasContactToVulnerablePeople').value"
+  >
     <mat-label>Wie und zu wem haben Sie Kontakt?*</mat-label>
     <mat-form-field class="full-width">
-      <input matInput required formControlName="hasContactToVulnerablePeopleDescription"/>
+      <input
+        matInput
+        required
+        formControlName="hasContactToVulnerablePeopleDescription"
+      />
     </mat-form-field>
   </div>
 </div>

--- a/frontend/src/app/modules/welcome/login/login.component.spec.ts
+++ b/frontend/src/app/modules/welcome/login/login.component.spec.ts
@@ -3,9 +3,9 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LoginComponent } from './login.component';
 import { SnackbarService } from '@services/snackbar.service';
 import { UserService } from '@services/user.service';
-import {HttpClientTestingModule} from '@angular/common/http/testing';
-import {Router} from '@angular/router';
-import {of} from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -15,6 +15,7 @@ describe('LoginComponent', () => {
     const userService = jasmine.createSpyObj(['login', 'isHealthDepartmentUser']);
     userService.isLoggedIn$ = of();
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       providers: [
         { provide: UserService, useValue: userService },
         { provide: SnackbarService, useValue: jasmine.createSpyObj(['success']) },

--- a/frontend/src/app/modules/welcome/register/register.component.html
+++ b/frontend/src/app/modules/welcome/register/register.component.html
@@ -57,15 +57,12 @@
       </mat-form-field>
       <mat-form-field class="form__input--full-width" appearance="outline" data-cy="input-password-confirm">
         <mat-label>Passwort bestätigen</mat-label>
-        <input matInput formControlName="passwordConfirm" placeholder="Passwort bestätigen" id="password-confirm"
-          type="password" />
-      </mat-form-field>
-      <div class="mat-form-field-subscript-wrapper ng-tns-c78-3"
-        *ngIf="registrationForm.hasError('passwordConfirmWrong')">
-        <mat-error>
+        <input matInput formControlName="passwordConfirm" [errorStateMatcher]="confirmValidParentMatcher"
+               placeholder="Passwort bestätigen" id="password-confirm" type="password" />
+        <mat-error *ngIf="registrationForm.hasError('passwordConfirmWrong')">
           Das Passwort und die Bestätigung müssen übereinstimmen.
         </mat-error>
-      </div>
+      </mat-form-field>
       <mat-form-field class="form__input--full-width" appearance="outline" data-cy="input-dateofbirth">
         <mat-label>Geburtsdatum</mat-label>
         <input matInput formControlName="dateOfBirth" [matDatepicker]="picker" [max]="today" />

--- a/frontend/src/app/modules/welcome/register/register.component.ts
+++ b/frontend/src/app/modules/welcome/register/register.component.ts
@@ -9,6 +9,7 @@ import {ApiService} from '@services/api.service';
 import {Register} from '@models/register';
 import {SnackbarService} from '@services/snackbar.service';
 import {VALIDATION_PATTERNS} from '@utils/validation';
+import {ConfirmValidPasswordMatcher} from '@validators/ConfirmValidPasswordMatcher';
 
 @Component({
   selector: 'app-register',
@@ -18,6 +19,7 @@ import {VALIDATION_PATTERNS} from '@utils/validation';
 export class RegisterComponent implements OnInit {
   today = new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate());
 
+  public confirmValidParentMatcher = new ConfirmValidPasswordMatcher();
   private usernameIsValid = false;
 
   public registrationForm = new FormGroup({

--- a/frontend/src/app/validators/ConfirmValidPasswordMatcher.ts
+++ b/frontend/src/app/validators/ConfirmValidPasswordMatcher.ts
@@ -1,0 +1,9 @@
+import {ErrorStateMatcher} from '@angular/material/core';
+import {FormControl, FormGroupDirective, NgForm} from '@angular/forms';
+import {PasswordValidator} from '@validators/password-validator';
+
+export class ConfirmValidPasswordMatcher implements ErrorStateMatcher {
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    return !!PasswordValidator.mustMatch(control.parent);
+  }
+}


### PR DESCRIPTION
mat errors are not displayed in the form-field if the corresponding controlForm has no error. The PasswordMatch validation  is registered in the FormGroup. Its error is therefore not rendered in the confirmPassword form-field. This is fixed with the errorStateMatcher, which doubleChecks for the ValidationError.