### PR TITLE
CORE-179: fix mapping of roles for Account-PUT Requests and fix valid…

### DIFF
--- a/backend/src/main/java/quarano/account/AccountBootstrap.java
+++ b/backend/src/main/java/quarano/account/AccountBootstrap.java
@@ -48,8 +48,6 @@ public class AccountBootstrap implements ApplicationRunner {
 		// create initial roles
 		for (RoleType type : RoleType.values()) {
 
-
-			
 			var role = roleRepository.findByName(type.getCode());
 
 			if (role != null) {

--- a/backend/src/main/java/quarano/account/RoleRepository.java
+++ b/backend/src/main/java/quarano/account/RoleRepository.java
@@ -7,4 +7,9 @@ public interface RoleRepository extends CrudRepository<Role, Integer> {
 
 	@Nullable
 	Role findByName(String roleName);
+
+	@Nullable
+	default Role findByRoleType(RoleType roleType) {
+		return this.findByName(roleType.getCode());
+	}
 }

--- a/backend/src/test/java/quarano/account/web/StaffAccountControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/account/web/StaffAccountControllerWebIntegrationTests.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.MediaType;
@@ -120,7 +119,6 @@ class StaffAccountControllerWebIntegrationTests {
 
 	@Test
 	@WithQuaranoUser("admin")
-	@Disabled
 	void rejectsInvalidCharactersForStringFieldsOnCreate() throws Exception {
 
 		var source = createTestUserInput(RoleType.ROLE_HD_CASE_AGENT, RoleType.ROLE_HD_ADMIN);
@@ -129,7 +127,7 @@ class StaffAccountControllerWebIntegrationTests {
 		source.setUsername("Demo ! A/Ccount");
 		source.setEmail("myT@estmaIl@test.com"); //
 		source.setFirstName("Hans123");
-		source.setFirstName("Huber123");
+		source.setLastName("Huber123");
 
 		// send request
 		var responseBody = mvc.perform(post("/api/hd/accounts") //
@@ -153,7 +151,6 @@ class StaffAccountControllerWebIntegrationTests {
 	
 	@Test
 	@WithQuaranoUser("admin")
-	@Disabled
 	void rejectsInvalidCharactersForStringFieldsOnUpdate() throws Exception {
 		
 		// get reference accounts
@@ -164,7 +161,7 @@ class StaffAccountControllerWebIntegrationTests {
 		dto.setUsername("Demo ! A/Ccount");
 		dto.setEmail("myT@estmaIl@test.com"); //
 		dto.setFirstName("Hans123");
-		dto.setFirstName("Huber123");
+		dto.setLastName("Huber123");
 		
 		var response = mvc.perform(put("/api/hd/accounts/" + agent1.get().getId())
 				.content(jackson.writeValueAsString(dto)) //

--- a/backend/src/test/java/quarano/account/web/StaffAccountRepresentationsIntegrationTest.java
+++ b/backend/src/test/java/quarano/account/web/StaffAccountRepresentationsIntegrationTest.java
@@ -1,0 +1,50 @@
+package quarano.account.web;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.RequiredArgsConstructor;
+import quarano.QuaranoIntegrationTest;
+import quarano.account.Account;
+import quarano.account.AccountService;
+import quarano.account.Role;
+import quarano.account.RoleType;
+import quarano.core.EmailAddress;
+
+import java.util.List;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+
+@QuaranoIntegrationTest
+@RequiredArgsConstructor
+class StaffAccountRepresentationsIntegrationTest {
+	private final AccountService accounts;
+	private final StaffAccountRepresentations representations;
+
+	@Test
+	void testFromUpdateDto() {
+		var username = "agent1";
+		var agent1 = accounts.findByUsername(username).get();
+
+		Account mappedAccount = representations.from(agent1, StaffAccountRepresentations.StaffAccountUpdateInputDto.of()
+				.setFirstName("Max")
+				.setLastName("Mustermann")
+				.setEmail("max.mustermann@acme.com")
+				.setUsername("agent0815")
+				.setRoles(List.of(RoleType.ROLE_HD_ADMIN.getCode()))
+		);
+
+		assertThat(mappedAccount.getFirstname()).isEqualTo("Max");
+		assertThat(mappedAccount.getLastname()).isEqualTo("Mustermann");
+		assertThat(mappedAccount.getEmail()).isEqualTo(EmailAddress.of("max.mustermann@acme.com"));
+		assertThat(mappedAccount.getUsername()).isEqualTo("agent0815");
+		assertThat(mappedAccount.getRoles()).haveExactly(1, new Condition<>("role") {
+			@Override
+			public boolean matches(Role value) {
+				return value.getRoleType().equals(RoleType.ROLE_HD_ADMIN);
+			}
+		});
+	}
+
+
+}


### PR DESCRIPTION
…ation messages for Account-POST/-PUT requests

* roles: The roles are manually mapped with database context as it is done during account-creation
* validation: Crazy stuff... The validation exception was not resolved anymore. That belongs to the @LoggedIn Resolver in any way. I don't know why. If we order the parameters like (..., Errors, @LoggedIn), it's working, if the ordering is like (..., @LoggedIn, Errors), its not. In that case, the controller method is not entered anymore and we're not able to return our badRequest() response as it is done normally.